### PR TITLE
added "Read on Wikipedia" feature

### DIFF
--- a/jump2Wikiwand.user.js
+++ b/jump2Wikiwand.user.js
@@ -4,7 +4,7 @@
 // @description:zh-CN   重定向 Wikipedia 页面到 Wikiwand 以获得现代的浏览体验
 // @description:zh-TW   重定向 Wikipedia 頁面到 Wikiwand 以獲得現代的瀏覽體驗
 // @author              ladit
-// @version             1.0.1
+// @version             1.2.0
 // @namespace           https://greasyfork.org/zh-CN/scripts/33223
 // @homepageURL         https://github.com/ladit/Userscripts
 // @supportURL          https://github.com/ladit/Userscripts

--- a/jump2Wikiwand.user.js
+++ b/jump2Wikiwand.user.js
@@ -14,5 +14,10 @@
 // @run-at              document-start
 // ==/UserScript==
 
-window.location.replace(document.URL.replace(/https?:\/\/([\w-]+)\.wikipedia\.org\/[\w-]+\/([^#&\?]+)/, 'https://www.wikiwand.com/$1/$2'));
+(function() {
+    'use strict';
+    if (!document.URL.includes('oldformat=true')) {
+      window.location.replace(document.URL.replace(/https?:\/\/([\w-]+)\.wikipedia\.org\/[\w-]+\/([^#&\?]+)/, 'https://www.wikiwand.com/$1/$2'));
+    }
+})();
 


### PR DESCRIPTION
Do not redirect to wikiwand if the **URL** includes the string `oldformat=true`. This is used by wikiwand to redirect back to Wikipedia.